### PR TITLE
Publish test results

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -66,6 +66,7 @@ permissions:
 env:
   ARCHERY_DEBUG: 1
   ARROW_ENABLE_TIMING_TESTS: OFF
+  ARROW_CTEST_OUTPUT_JUNIT: junit-results.xml
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
@@ -137,6 +138,7 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          ARROW_CTEST_OUTPUT_JUNIT: /arrow/cpp/${{ env.ARROW_CTEST_OUTPUT_JUNIT }}
         run: |
           # GH-40558: reduce ASLR to avoid ASAN/LSAN crashes
           sudo sysctl -w vm.mmap_rnd_bits=28
@@ -153,6 +155,12 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
         run: archery docker push ${{ matrix.image }}
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-cpp-docker-${{ matrix.image }}
+          path: './cpp/${{ env.ARROW_CTEST_OUTPUT_JUNIT }}'
 
   build-example:
     name: C++ Minimal Build Example
@@ -264,6 +272,12 @@ jobs:
           sudo sysctl -w kern.corefile=/tmp/core.%N.%P
           ulimit -c unlimited  # must enable within the same shell
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-cpp-macos-${{ matrix.architecture }}-${{ matrix.macos-version }}
+          path: './build/cpp/${{ env.ARROW_CTEST_OUTPUT_JUNIT }}'
 
   windows:
     name: ${{ matrix.title }}
@@ -360,6 +374,12 @@ jobs:
           # For ORC
           export TZDIR=/c/msys64/usr/share/zoneinfo
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-cpp-windows-${{ matrix.simd-level }}
+          path: './build/cpp/${{ env.ARROW_CTEST_OUTPUT_JUNIT }}'
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.msystem_upper }} C++
@@ -468,3 +488,19 @@ jobs:
         shell: msys2 {0}
         run: |
           ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-cpp-windows-mingw-${{ matrix.msystem_lower }}
+          path: './build/cpp/${{ env.ARROW_CTEST_OUTPUT_JUNIT }}'
+
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -502,5 +502,5 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: Event File
+        name: Event
         path: ${{ github.event_path }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-csharp-ubuntu-${{ matrix.dotnet }}
+          path: './csharp/test/**/TestResults/TestResults.xml'
 
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
@@ -96,6 +102,12 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-csharp-windows-${{ matrix.dotnet }}
+          path: './csharp/test/**/TestResults/TestResults.xml'
 
   macos:
     name: AMD64 macOS 13 C# ${{ matrix.dotnet }}
@@ -125,6 +137,12 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-csharp-macos-${{ matrix.dotnet }}
+          path: './csharp/test/**/TestResults/TestResults.xml'
 
   package:
     name: Package
@@ -210,3 +228,13 @@ jobs:
             *.snupkg
         env:
           GH_TOKEN: ${{ github.token }}
+
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -236,5 +236,5 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: Event File
+        name: Event
         path: ${{ github.event_path }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -47,6 +47,7 @@ permissions:
 
 env:
   ARCHERY_DEBUG: 1
+  TEST_REPORT_PATH: js/
 
 jobs:
 
@@ -70,6 +71,7 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          TEST_REPORT_PATH: /arrow/${{ env.TEST_REPORT_PATH }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run debian-js
@@ -84,6 +86,12 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
         run: archery docker push debian-js
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-js-docker-debian-js
+          path: ${{ env.TEST_REPORT_PATH }}/test-report.xml
 
   macos:
     name: AMD64 macOS 13 NodeJS ${{ matrix.node }}
@@ -113,8 +121,16 @@ jobs:
         shell: bash
         run: ci/scripts/js_build.sh $(pwd) build
       - name: Test
+        env:
+          TEST_REPORT_PATH: ../../${{ env.TEST_REPORT_PATH }}
         shell: bash
         run: ci/scripts/js_test.sh $(pwd) build
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-js-macos-${{ matrix.node }}
+          path: ${{ env.TEST_REPORT_PATH }}/test-report.xml
 
   windows:
     name: AMD64 Windows NodeJS ${{ matrix.node }}
@@ -144,5 +160,23 @@ jobs:
         shell: bash
         run: ci/scripts/js_build.sh $(pwd) build
       - name: Test
+        env:
+          TEST_REPORT_PATH: ../../${{ env.TEST_REPORT_PATH }}
         shell: bash
         run: ci/scripts/js_test.sh $(pwd) build
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-js-windows-${{ matrix.node }}
+          path: ${{ env.TEST_REPORT_PATH }}/test-report.xml
+
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -178,5 +178,5 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: Event File
+        name: Event
         path: ${{ github.event_path }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -123,6 +123,7 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          PYTEST_ARGS: --junit-xml /arrow/python/pytest.xml
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ${{ matrix.image }}
@@ -137,6 +138,12 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
         run: archery docker push ${{ matrix.image }}
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-python-docker-${{ matrix.name }}
+          path: python/pytest.xml
 
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3
@@ -174,6 +181,7 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ON
+      PYTEST_ARGS: --junit-xml python/pytest.xml
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:
@@ -224,3 +232,19 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/python_test.sh $(pwd) $(pwd)/build
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-python-macos-${{ matrix.architecture }}-${{ matrix.macos-version }}
+          path: python/pytest.xml
+
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -246,5 +246,5 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: Event File
+        name: Event
         path: ${{ github.event_path }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -36,16 +36,11 @@ jobs:
     if: github.event.workflow_run.conclusion != 'skipped'
 
     permissions:
+      # required to create check status
       checks: write
 
-      # needed unless run with comment_mode: off
+      # required to write comment to pull request
       pull-requests: write
-
-      # only needed for private repository
-      contents: read
-
-      # only needed for private repository
-      issues: read
 
       # required by download step to access artifacts API
       actions: read

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Test Results
+run-name: Test Results (${{ github.event.workflow.name }}) [${{ github.event.workflow_run.event }}]
+
+on:
+  workflow_run:
+    workflows:
+      - 'C\+\+'
+      - 'C#'
+      - 'NodeJS'
+      - 'Python'
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+
+      # needed unless run with comment_mode: off
+      pull-requests: write
+
+      # only needed for private repository
+      contents: read
+
+      # only needed for private repository
+      issues: read
+
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+           run_id: ${{ github.event.workflow_run.id }}
+           path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: Test Results (${{ github.event.workflow.name }}) [${{ github.event.workflow_run.event }}]
+          comment_mode: ${{ github.event.workflow_run.event == 'pull_request' && 'always' || 'off' }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -63,6 +63,6 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: Test Results (${{ github.event.workflow.name }}) [${{ github.event.workflow_run.event }}]
           comment_mode: ${{ github.event.workflow_run.event == 'pull_request' && 'always' || 'off' }}
-          event_file: artifacts/Event File/event.json
+          event_file: artifacts/Event/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -46,10 +46,19 @@ jobs:
       actions: read
 
     steps:
-      - name: Download and Extract Artifacts
+      - name: Download event file
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
         with:
            run_id: ${{ github.event.workflow_run.id }}
+           name: Event
+           path: artifacts
+
+      - name: Download test results
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+           run_id: ${{ github.event.workflow_run.id }}
+           name: ^test-results-.*
+           name_is_regexp: true
            path: artifacts
 
       - name: Publish Test Results

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -47,14 +47,14 @@ jobs:
 
     steps:
       - name: Download event file
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295  # v9
         with:
            run_id: ${{ github.event.workflow_run.id }}
            name: Event
            path: artifacts
 
       - name: Download test results
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295  # v9
         with:
            run_id: ${{ github.event.workflow_run.id }}
            name: ^test-results-.*

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -51,7 +51,7 @@ jobs:
         with:
            run_id: ${{ github.event.workflow_run.id }}
            name: Event
-           path: artifacts
+           path: artifacts/Event/
 
       - name: Download test results
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295  # v9

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -95,6 +95,9 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     --print-errorlogs \
     "$@"
 else
+  if [ -n "$ARROW_CTEST_OUTPUT_JUNIT" ]; then
+    ctest_options+=(--output-junit "${ARROW_CTEST_OUTPUT_JUNIT}")
+  fi
   ctest \
     --label-regex unittest \
     --output-on-failure \

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -33,5 +33,5 @@ ${PYTHON} -m pip install pyarrow find-libpython
 export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
 
 pushd ${source_dir}
-dotnet test
+dotnet test --logger "xunit;LogFileName=TestResults.xml"
 popd

--- a/csharp/test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Flight.Sql.Tests/Apache.Arrow.Flight.Sql.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Sql.Tests/Apache.Arrow.Flight.Sql.Tests.csproj
@@ -9,6 +9,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
       <PackageReference Include="coverlet.collector" Version="6.0.4" />
     </ItemGroup>
 

--- a/csharp/test/Apache.Arrow.Flight.Sql.Tests/Apache.Arrow.Flight.Sql.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Sql.Tests/Apache.Arrow.Flight.Sql.Tests.csproj
@@ -9,7 +9,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
+      <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
       <PackageReference Include="coverlet.collector" Version="6.0.4" />
     </ItemGroup>
 

--- a/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.skippablefact" Version="1.5.23" />
+    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
     <PackageReference Include="pythonnet" Version="3.0.5" />
   </ItemGroup>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,6 +292,7 @@ services:
       ARROW_EXTRA_ERROR_CONTEXT: "ON"
       ARROW_MIMALLOC: "ON"
       ARROW_USE_LD_GOLD: "ON"
+      ARROW_CTEST_OUTPUT_JUNIT:  #inherit
       BUILD_DOCS_PYTHON: "ON"
     volumes: &conda-volumes
       - .:/arrow:delegated
@@ -403,6 +404,7 @@ services:
     environment:
       <<: [*common, *ccache, *sccache, *cpp]
       ARROW_ENABLE_TIMING_TESTS:  # inherit
+      ARROW_CTEST_OUTPUT_JUNIT:  # inherit
       ARROW_MIMALLOC: "ON"
     volumes: &ubuntu-volumes
       - .:/arrow:delegated
@@ -651,6 +653,7 @@ services:
       ARROW_S3: "OFF"
       ARROW_USE_ASAN: "ON"
       ARROW_USE_UBSAN: "ON"
+      ARROW_CTEST_OUTPUT_JUNIT:  # inherit
       # 1 GB isn't enough for a single sanitizer build
       CCACHE_MAXSIZE: 2G
       Protobuf_SOURCE: "AUTO"
@@ -1383,6 +1386,7 @@ services:
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
       PANDAS_FUTURE_INFER_STRING:  # inherit
+      ARROW_CTEST_OUTPUT_JUNIT:  # inherit
     volumes: *conda-volumes
     command: *python-conda-command
 
@@ -1407,6 +1411,7 @@ services:
     environment:
       <<: [*common, *ccache, *sccache]
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
+      PYTEST_ARGS:  # inherit
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes
@@ -1434,7 +1439,7 @@ services:
       LANG: "C.UTF-8"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
-      PYTEST_ARGS: "--doctest-modules --doctest-cython"
+      PYTEST_ARGS: "--doctest-modules --doctest-cython --junit-xml /arrow/python/pytest.xml"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
@@ -1710,6 +1715,7 @@ services:
     environment:
       <<: *common
       BUILD_DOCS_JS: "ON"
+      TEST_REPORT_PATH:  # inherit
     command: &js-command >
       /bin/bash -c "
         /arrow/ci/scripts/js_build.sh /arrow /build &&

--- a/js/jest.config.js
+++ b/js/jest.config.js
@@ -25,6 +25,7 @@ export default {
     cacheDirectory: ".jest-cache",
     extensionsToTreatAsEsm: [".ts"],
     moduleFileExtensions: ["js", "mjs", "ts"],
+    testResultsProcessor: "./node_modules/jest-junit-reporter",
     coverageReporters: ["lcov", "json",],
     coveragePathIgnorePatterns: [
         "fb\\/.*\\.(js|ts)$",

--- a/js/package.json
+++ b/js/package.json
@@ -97,6 +97,7 @@
     "gulp-vinyl-size": "1.1.4",
     "ix": "7.0.0",
     "jest": "29.7.0",
+    "jest-junit-reporter": "1.1.0",
     "jest-silent-reporter": "0.6.0",
     "memfs": "4.17.0",
     "mkdirp": "3.0.1",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -4564,6 +4564,13 @@ jest-haste-map@^29.7.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-junit-reporter@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-junit-reporter/-/jest-junit-reporter-1.1.0.tgz"
+  integrity sha512-beZH/+kAQbECfvXKrm1g0VFxUPC+cezPMHeqhP9y6ThlRjvxFvfwlUQElYIN9P1tW+odHz8nIz9VV2BdWsUlfw==
+  dependencies:
+    xml "^1.0.1"
+
 jest-leak-detector@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"


### PR DESCRIPTION
### Rationale for this change
Unit test results are currently not very accessible other than scrolling through long logs.
Changes in the number of tests, skipped tests or flaky tests are not very visible in the Github UI.
Better accessibility and visibility of test results helps identifying and investigating issues.

### What changes are included in this PR?
This generates test results for C++, C#, Python and NodeJS. Uploads these test result files so they become available as artifacts. Finally, these artifacts are processed by an action and stats visualized in pull requests and check statuses.

For a full list of features of this visualization in Github, see https://github.com/EnricoMi/publish-unit-test-result-action#publishing-test-results. Disclaimer: I am the author of this action.

This supports pull requests from fork repositories.

### Are these changes tested?
Yes: https://github.com/EnricoMi/arrow/pull/14

### Are there any user-facing changes?
Only CI.